### PR TITLE
Add secrets.yml file back to lab and remove it from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ pickle-email-*.html
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
-config/secrets.yml
 
 ## Environment normalization:
 /.bundle

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: c05fe83eb4cd2f4f87dcb280f89c4336a1c93deca0d01ec0e535c63fdf762b74e6d31235323665d766211de551b1e7ed2c8ec8073fdbcdac8b9f1bb645ebf943
+
+test:
+  secret_key_base: 3dd314c3109ff7c4047b551070fd030c7c4ef19175c7f51c871539406385c72387d6710b088e3112f601f0a1e9ef59635a6d8d584a2df41b2941ff05d76a53bf
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Lab would not run properly after secrets.yml file was removed.
Adding it back so that tests will pass again for students.

@jmburges @PeterBell 