### PR TITLE
change tests to expect consistent POST input to create

### DIFF
--- a/spec/features/coupon_spec.rb
+++ b/spec/features/coupon_spec.rb
@@ -25,8 +25,8 @@ describe 'form page' do
   it 'new form submits content and renders form content' do
     visit new_coupon_path
 
-    fill_in 'coupon_code', with: "YAYFREE"
-    fill_in 'store', with: "Hobby Lobby"
+    fill_in 'coupon[coupon_code]', with: "YAYFREE"
+    fill_in 'coupon[store]', with: "Hobby Lobby"
 
     click_on "Submit Coupon"
 
@@ -36,8 +36,8 @@ describe 'form page' do
   it 'creates a record in the database' do
     visit new_coupon_path
 
-    fill_in 'coupon_code', with: "FREEITEM"
-    fill_in 'store', with: "Quip"
+    fill_in 'coupon[coupon_code]', with: "FREEITEM"
+    fill_in 'coupon[store]', with: "Quip"
 
     click_on "Submit Coupon"
 


### PR DESCRIPTION
In the previous tests you had a complex issue to work around in the tests due to an inconsistency between `spec/features/coupons_controller_spec.rb` and `spec/controllers/coupons_spec.rb`.

In `spec/controllers/coupons_controller_spec.rb` the tests expected the `params` hash to have the `:coupon_code` and `:store` keys nested in a `:coupon` key when passed to the `#create` function.

In `spec/controllers/coupons_spec.rb` the tests where requiring that the form use the names `coupon_code `and `store` for the text inputs. This (due to the method prescribed in the readme,) required that the params hash would not nest the `:coupon_code` and `:store` and would have them lay flat on the top layer instead.

While this could be achived if they added `"", id: "coupon_code/store"` to the `text_field_tag` call I think it would be beneficial to future students not to have this headache by introducing consistent expectations to the testing suite.

Therefore I am proposing that `coupon[` . . . `]` to the tests so that one solution will cover both.